### PR TITLE
Handle subscriber failures better

### DIFF
--- a/lib/mqttListener.js
+++ b/lib/mqttListener.js
@@ -106,14 +106,17 @@ module.exports = function( subscriber, mqttStatus ) {
         };
 
         client.on( 'message', function( topic, message, packet ) {
-            subscriber.receive(
-                topic,
-                message,
-                {
-                    client: subscriberClient,
-                    packet: packet
-                }
-            );
+
+            const extras = {
+                client: subscriberClient,
+                packet: packet
+            };
+
+            Promise
+                .try( () => subscriber.receive( topic, message, extras ) )
+                .catch( err => {
+                    log.error( { err, topic }, 'unexpected subscriber failure' );
+                } );
         } );
     } );
 };

--- a/lib/subscriberMerger.js
+++ b/lib/subscriberMerger.js
@@ -88,19 +88,19 @@ module.exports = function( subscribers ) {
                 if( topic.match( subscription.regex ) ) {
 
                     return subscription.subscribers.forEach( function( subscriber ) {
-                        Promise.try(
-                            () => subscriber.receive( topic, message, extras )
-                        ).catch( err => {
-                            log.error(
-                                {
-                                    err,
-                                    topic,
-                                    subscriber: subscriber.name,
-                                    subscription: subscriber.subscription
-                                },
-                                'unexpected subscriber failure'
-                            );
-                        } );
+                        Promise
+                            .try( () => subscriber.receive( topic, message, extras ) )
+                            .catch( err => {
+                                log.error(
+                                    {
+                                        err,
+                                        topic,
+                                        subscriber: subscriber.name,
+                                        subscription: subscriber.subscription
+                                    },
+                                    'unexpected subscriber failure'
+                                );
+                            } );
                     } );
                 }
             } );

--- a/lib/subscriberMerger.js
+++ b/lib/subscriberMerger.js
@@ -3,6 +3,7 @@
 var _ = require( 'lodash' );
 var log = require( './log.js' );
 var mqttRegexBuilder = require( 'mqtt-regex-builder' );
+var Promise = require( 'bluebird' );
 
 function mergeSubscription( subscriber, subscription, map ) {
 
@@ -87,7 +88,19 @@ module.exports = function( subscribers ) {
                 if( topic.match( subscription.regex ) ) {
 
                     return subscription.subscribers.forEach( function( subscriber ) {
-                        subscriber.receive( topic, message, extras );
+                        Promise.try(
+                            () => subscriber.receive( topic, message, extras )
+                        ).catch( err => {
+                            log.error(
+                                {
+                                    err,
+                                    topic,
+                                    subscriber: subscriber.name,
+                                    subscription: subscriber.subscription
+                                },
+                                'unexpected subscriber failure'
+                            );
+                        } );
                     } );
                 }
             } );

--- a/test/mqttListenerTests.js
+++ b/test/mqttListenerTests.js
@@ -5,6 +5,7 @@ const mqtt = require( 'mqtt' );
 const mqttPacket = require( 'mqtt-packet' );
 const net = require( 'net' );
 const Promise = require( 'bluebird' );
+const sinon = require( 'sinon' );
 
 const brokerUrl = 'mqtt://localhost';
 
@@ -19,6 +20,7 @@ process.env = {
 const conf = require( '../lib/conf.js' );
 const mqttListener = require( '../lib/mqttListener.js' );
 const MqttStatus = require( '../lib/MqttStatus.js' );
+const log = require( '../lib/log.js' );
 
 describe( 'mqttListener', function() {
 
@@ -61,6 +63,65 @@ describe( 'mqttListener', function() {
 
                             assert.equal( recieved.topic, 'mqttListener/example' );
                             assert.equal( recieved.message, 'from the cloud' );
+                        } )
+                        .finally( function() {
+                            listener.stop();
+                        } );
+                } );
+        } );
+    } );
+
+    describe( 'when lone subscriber throws', function() {
+        beforeEach( () => sinon.stub( log, 'error' ) );
+        afterEach( () => log.error.restore() );
+
+        it( 'should log', function() {
+
+            const topic = 'mqttListener/example';
+            const err = new Error( 'simulated client failure' );
+
+            const mqttStatus = new MqttStatus();
+
+            var testSubscriber = {
+                subscription: {
+                    topic: 'mqttListener/example'
+                },
+                receive: () => assert.fail( 'should never be called' )
+            };
+
+            var receiveP = new Promise( function( resolve, reject ) {
+                testSubscriber.receive = function() {
+                    resolve();
+                    return Promise.reject( err );
+                };
+            } );
+
+            return mqttListener( testSubscriber, mqttStatus )
+                .then( function( listener ) {
+
+                    assert( mqttStatus.connected, 'should be connected' );
+                    assert( mqttStatus.subscribed, 'should be connected' );
+
+                    var testClient = Promise.promisifyAll( mqtt.connect( brokerUrl ) );
+                    return testClient
+                        .publishAsync( 'mqttListener/example', 'from the cloud' )
+                        .then( function() {
+
+                            testClient.end();
+                        } )
+                        .then( function() {
+                            // wait on the receive promise
+                            return receiveP;
+                        } )
+                        .delay( 1 ) // We need to let mqttListener handle the rejected promise first
+                        .then( function() {
+
+                            sinon.assert.called(
+                                log.error,
+                                { err, topic },
+                                'unexpected subscriber failure'
+                            );
+
                         } )
                         .finally( function() {
                             listener.stop();

--- a/test/subscriberMergerTests.js
+++ b/test/subscriberMergerTests.js
@@ -6,18 +6,19 @@ var sinon = require( 'sinon' );
 var log = require( '../lib/log.js' );
 var subscriberMerger = require( '../lib/subscriberMerger.js' );
 
-var logWarnSpy = sinon.spy( log, 'warn' );
-var logErrorSpy = sinon.spy( log, 'error' );
-
-function resetSpies() {
-    logWarnSpy.reset();
-    logErrorSpy.reset();
-}
-
 describe( 'subscriberMerger', function() {
 
-    beforeEach( resetSpies );
-    after( resetSpies );
+    var logWarnSpy;
+    var logErrorSpy;
+
+    beforeEach( () => {
+        logWarnSpy = sinon.spy( log, 'warn' );
+        logErrorSpy = sinon.spy( log, 'error' );
+    } );
+    afterEach( () => {
+        logWarnSpy.restore();
+        logErrorSpy.restore();
+    } );
 
     describe( 'when no subscribers', function() {
         it( 'should throw', function() {

--- a/test/subscriberMergerTests.js
+++ b/test/subscriberMergerTests.js
@@ -403,4 +403,69 @@ describe( 'subscriberMerger', function() {
         } );
     } );
 
+    describe( 'receive', function() {
+
+        describe( 'when first subscriber throws', function() {
+            it( 'should still call subsequent subscribers', function() {
+
+                var subscriberA = {
+                    subscription: {
+                        topic: 'test/+',
+                        qos: 0
+                    },
+                    receive: sinon.stub().throws( new Error() )
+                };
+
+                var subscriberB = {
+                    subscription: {
+                        topic: '#',
+                        qos: 1
+                    },
+                    receive: sinon.spy()
+                };
+
+                var ret = subscriberMerger( [ subscriberA, subscriberB ] );
+
+                var topic = 'test/try';
+                var msg = 'ignored';
+
+                ret.receive( topic, msg );
+
+                sinon.assert.calledOnce( subscriberA.receive );
+                sinon.assert.calledOnce( subscriberB.receive );
+            } );
+        } );
+
+        describe( 'when first subscriber returns rejected Promise', function() {
+            it( 'should still call subsequent subscribers', function() {
+
+                var subscriberA = {
+                    subscription: {
+                        topic: 'test/+',
+                        qos: 0
+                    },
+                    receive: sinon.stub().returns( Promise.reject() )
+                };
+
+                var subscriberB = {
+                    subscription: {
+                        topic: '#',
+                        qos: 1
+                    },
+                    receive: sinon.spy()
+                };
+
+                var ret = subscriberMerger( [ subscriberA, subscriberB ] );
+
+                var topic = 'test/try';
+                var msg = 'ignored';
+
+                ret.receive( topic, msg );
+
+                sinon.assert.calledOnce( subscriberA.receive );
+                sinon.assert.calledOnce( subscriberB.receive );
+            } );
+        } );
+    } );
+
 } );


### PR DESCRIPTION
We now catch subscribers failures (whether throws or rejected Promises) and
log the error.  Previous behaviour was undefined.